### PR TITLE
Add: added install support for windows hosts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,25 @@
   "type": "module",
   "scripts": {
     "build": "tsc && chmod 755 build/src/index.js && mkdir -p build/test",
+    "build:win": "tsc && if not exist build\\test mkdir build\\test",
+
     "start": "node build/src/index.js",
     "dev": "tsc && node build/src/index.js",
+
     "test": "pnpm run build && node build/test/final-test.js",
+    "test:win": "pnpm run build:win && node build/test/final-test.js",
+
     "test:get-thread": "pnpm run build && node build/test/tools/test-get-post-thread.js",
+    "test:get-thread:win": "pnpm run build:win && node build/test/tools/test-get-post-thread.js",
+
     "test:url-converter": "pnpm run build && node build/test/url-converter/test-url-converter.js",
+    "test:url-converter:win": "pnpm run build:win && node build/test/url-converter/test-url-converter.js",
+
     "process-posts": "pnpm run build && node build/src/scripts/process-post-examples.js",
-    "process-threads": "pnpm run build && node build/src/scripts/process-thread-examples.js"
+    "process-posts:win": "pnpm run build:win && node build/src/scripts/process-post-examples.js",
+
+    "process-threads": "pnpm run build && node build/src/scripts/process-thread-examples.js",
+    "process-threads:win": "pnpm run build:win && node build/src/scripts/process-thread-examples.js"
   },
   "keywords": [
     "bluesky",
@@ -21,7 +33,7 @@
   ],
   "author": "Brian Ellin",
   "license": "MIT",
-  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0",
+  "packageManager": "pnpm@9.15.4",
   "dependencies": {
     "@atproto/api": "^0.14.9",
     "@modelcontextprotocol/sdk": "^1.7.0",


### PR DESCRIPTION
The provided `package.json` works on Linux and macos hosts, but not for windows.

The commit change just adds this support, but it now the installation is done with the following commands:

```bash
# For linux/mac (as it is already)
pnpm run build

# For windows
pnpm run build:win
```