### PR TITLE
Fix reply threading to properly set root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -243,12 +243,28 @@ server.tool(
           }
           
           const threadPost = cidResponse.data.thread as any;
-          const parentCid = threadPost.post.cid;
-          
+          const parentPost = threadPost.post;
+          const parentCid = parentPost.cid;
+          const parentRecord = parentPost.record;
+
+          // Determine the root - if parent is a reply, use its root, otherwise parent is the root
+          let rootUri: string;
+          let rootCid: string;
+
+          if (parentRecord.reply) {
+            // Parent is a reply - use its root
+            rootUri = parentRecord.reply.root.uri;
+            rootCid = parentRecord.reply.root.cid;
+          } else {
+            // Parent is a top-level post - it IS the root
+            rootUri = replyTo;
+            rootCid = parentCid;
+          }
+
           // Add reply information to the record
           record.reply = {
             parent: { uri: replyTo, cid: parentCid },
-            root: { uri: replyTo, cid: parentCid }
+            root: { uri: rootUri, cid: rootCid }
           };
 
         } catch (error) {


### PR DESCRIPTION
## Summary
Fixes a bug where replying to a nested reply incorrectly sets both `parent` and `root` to the same values, breaking thread rendering in the Bluesky web UI.

## Problem
When replying to a reply (nested thread), the code was setting:
- `parent`: the immediate post being replied to ✅ 
- `root`: **also** the immediate post (❌ should be the original thread root)

This causes threads to be orphaned and not render correctly in the Bluesky web UI, as seen in posts like https://bsky.app/profile/lizthegrey.com/post/3mbeybsgxti2f

## Solution
After fetching the parent post via `getPostThread`, check if the parent is itself a reply:
- If yes: use the parent's `reply.root` as our root (it's a nested reply)
- If no: the parent IS the root (it's a top-level post)

## Changes
- **File**: `src/index.ts` (lines 245-268)
- Properly traverses to find the actual thread root
- Preserves correct parent-child relationships

## Testing
- Build passes TypeScript checks
- Creates properly linked reply chains for nested replies
- Threads should now render correctly in Bluesky web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 (1M context) <noreply@anthropic.com>