### PR TITLE
Add search syntax hints to search-posts tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -302,9 +302,9 @@ ${profile.labels?.length ? `Labels: ${profile.labels.map((l: any) => l.val).join
 
 server.tool(
   "search-posts",
-  "Search for posts on Bluesky",
+  "Search for posts on Bluesky. Note: Bluesky uses strict AND matching - all search terms must be present in a post for it to match. This differs from web search engines which use loose/fuzzy matching. Searching for 'a b c' requires ALL of a, b, AND c to appear in matching posts. Supported operators: from:handle, to:handle, mentions:handle, url:domain, lang:code (e.g., lang:en), has:images, has:video, has:link.",
   {
-    query: z.string().describe("Search query"),
+    query: z.string().describe("Search query. Uses strict AND matching - all terms must match. Supported operators: from:, to:, mentions:, url:, lang:, has:images, has:video, has:link"),
     limit: z.number().min(1).max(100).default(50).describe("Number of results to fetch (1-100)"),
     sort: z.enum(["top", "latest"]).default("top").describe("Sort order for search results - 'top' for most relevant or 'latest' for most recent"),
   },


### PR DESCRIPTION
## Summary
Documents that Bluesky uses strict AND matching for search queries, and adds documentation for supported search operators.

## Problem
Users expect web search-style loose/fuzzy matching, but Bluesky uses strict AND matching where **all** search terms must be present in a post for it to match. Searching for "a b c" requires ALL three terms to appear, not just any of them.

This causes confusion when search doesn't work like web search tools users are familiar with.

## Solution
Update the `search-posts` tool description to:
1. Explain strict AND matching behavior
2. Clarify the difference from web search engines
3. Document supported search operators

## Changes
- **File**: `src/index.ts` (lines 303-307)
- Updated tool description with search behavior explanation
- Updated query parameter description with operator documentation
- Documented operators: `from:`, `to:`, `mentions:`, `url:`, `lang:`, `has:images`, `has:video`, `has:link`

## Testing
- Build passes TypeScript checks
- Documentation-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 (1M context) <noreply@anthropic.com>