### PR TITLE
Add facets and preview cards to create-post tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,21 +2,23 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { AtpAgent } from "@atproto/api";
+import { AtpAgent, RichText } from "@atproto/api";
 import * as dotenv from "dotenv";
-import {  
+import {
   cleanHandle,
-  formatSummaryText, 
-  getFeedNameFromId, 
+  formatSummaryText,
+  getFeedNameFromId,
   validateUri,
   McpErrorResponse,
   McpSuccessResponse,
   escapeXml,
-  convertBskyUrlToAtUri
+  convertBskyUrlToAtUri,
+  extractFirstUrl
 } from './utils.js';
 import { preprocessPosts, formatPostThread } from "./llm-preprocessor.js";
 import { registerResources, resourcesList } from './resources.js';
 import { registerPrompts } from './prompts.js';
+import { fetchLinkMetadata, uploadThumbnail } from './link-preview.js';
 
 // Load environment variables
 dotenv.config({ path: '.env' });
@@ -215,17 +217,28 @@ server.tool(
   {
     text: z.string().max(300).describe("The content of your post"),
     replyTo: z.string().optional().describe("Optional URI of post to reply to"),
+    previewUrl: z.string().url().optional().describe("Optional URL to generate preview card for. If not provided, uses first URL detected in text."),
+    embedPreview: z.boolean().optional().default(true).describe("Whether to fetch and attach a link preview card. Defaults to true."),
   },
-  async ({ text, replyTo }) => {
+  async ({ text, replyTo, previewUrl, embedPreview = true }) => {
     if (!agent) {
       return mcpErrorResponse("Not connected to Bluesky. Check your environment variables.");
     }
 
     try {
+      // Detect facets using RichText
+      const rt = new RichText({ text });
+      await rt.detectFacets(agent);
+
       const record: any = {
-        text,
+        text: rt.text,
         createdAt: new Date().toISOString(),
       };
+
+      // Add facets if any were detected
+      if (rt.facets && rt.facets.length > 0) {
+        record.facets = rt.facets;
+      }
 
       let replyRef;
       if (replyTo) {
@@ -253,6 +266,36 @@ server.tool(
 
         } catch (error) {
           return mcpErrorResponse(`Error parsing reply URI: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
+
+      // Generate link preview embed if enabled
+      if (embedPreview) {
+        const urlToPreview = previewUrl || extractFirstUrl(text);
+
+        if (urlToPreview) {
+          const metadata = await fetchLinkMetadata(urlToPreview);
+
+          if (metadata) {
+            const externalEmbed: any = {
+              $type: 'app.bsky.embed.external',
+              external: {
+                uri: metadata.url,
+                title: metadata.title,
+                description: metadata.description,
+              },
+            };
+
+            // Try to upload thumbnail if image URL exists
+            if (metadata.imageUrl) {
+              const thumbBlob = await uploadThumbnail(agent, metadata.imageUrl);
+              if (thumbBlob) {
+                externalEmbed.external.thumb = thumbBlob;
+              }
+            }
+
+            record.embed = externalEmbed;
+          }
         }
       }
 

--- a/src/link-preview.ts
+++ b/src/link-preview.ts
@@ -1,0 +1,154 @@
+import type { AtpAgent, BlobRef } from '@atproto/api';
+
+export interface LinkMetadata {
+  url: string;
+  title: string;
+  description: string;
+  imageUrl?: string;
+}
+
+/**
+ * Fetch Open Graph metadata from a URL
+ * Uses native fetch (available in Node 18+)
+ */
+export async function fetchLinkMetadata(url: string): Promise<LinkMetadata | null> {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Bluesky MCP Server/1.0',
+        'Accept': 'text/html',
+      },
+      signal: AbortSignal.timeout(5000), // 5 second timeout
+    });
+
+    if (!response.ok) {
+      console.error(`Failed to fetch ${url}: ${response.status}`);
+      return null;
+    }
+
+    const html = await response.text();
+    return parseOgMetadata(html, url);
+  } catch (error) {
+    console.error(`Error fetching link metadata for ${url}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Parse OG/Twitter Card metadata from HTML
+ */
+function parseOgMetadata(html: string, url: string): LinkMetadata {
+  // Helper to extract meta content (handles both orders of property/content)
+  const getMeta = (property: string): string | null => {
+    // Pattern 1: property="..." content="..."
+    const pattern1 = new RegExp(`<meta[^>]*property=["']${property}["'][^>]*content=["']([^"']+)["']`, 'i');
+    // Pattern 2: content="..." property="..."
+    const pattern2 = new RegExp(`<meta[^>]*content=["']([^"']+)["'][^>]*property=["']${property}["']`, 'i');
+    // Twitter card uses 'name' instead of 'property'
+    const pattern3 = new RegExp(`<meta[^>]*name=["']${property}["'][^>]*content=["']([^"']+)["']`, 'i');
+    const pattern4 = new RegExp(`<meta[^>]*content=["']([^"']+)["'][^>]*name=["']${property}["']`, 'i');
+
+    const match = html.match(pattern1) || html.match(pattern2) ||
+                  html.match(pattern3) || html.match(pattern4);
+    return match ? decodeHtmlEntities(match[1]) : null;
+  };
+
+  // Try OG tags first, fall back to Twitter Card, then standard HTML
+  const title = getMeta('og:title') ||
+                getMeta('twitter:title') ||
+                extractTitleTag(html) ||
+                url;
+
+  const description = getMeta('og:description') ||
+                      getMeta('twitter:description') ||
+                      getMeta('description') ||
+                      '';
+
+  const imageUrl = getMeta('og:image') ||
+                   getMeta('twitter:image') ||
+                   getMeta('twitter:image:src');
+
+  return {
+    url,
+    title: title.substring(0, 300), // Bluesky has length limits
+    description: description.substring(0, 1000),
+    imageUrl: imageUrl ? resolveUrl(imageUrl, url) : undefined,
+  };
+}
+
+function extractTitleTag(html: string): string | null {
+  const match = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+  return match ? decodeHtmlEntities(match[1].trim()) : null;
+}
+
+function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'");
+}
+
+function resolveUrl(imageUrl: string, baseUrl: string): string {
+  try {
+    return new URL(imageUrl, baseUrl).href;
+  } catch {
+    return imageUrl;
+  }
+}
+
+/**
+ * Download image and upload to Bluesky
+ * Returns BlobRef for the uploaded image
+ */
+export async function uploadThumbnail(
+  agent: AtpAgent,
+  imageUrl: string
+): Promise<BlobRef | null> {
+  try {
+    const response = await fetch(imageUrl, {
+      headers: {
+        'User-Agent': 'Bluesky MCP Server/1.0',
+      },
+      signal: AbortSignal.timeout(10000), // 10 second timeout for images
+    });
+
+    if (!response.ok) {
+      console.error(`Failed to download image ${imageUrl}: ${response.status}`);
+      return null;
+    }
+
+    const contentType = response.headers.get('content-type') || 'image/jpeg';
+
+    // Validate it's an image
+    if (!contentType.startsWith('image/')) {
+      console.error(`URL is not an image: ${contentType}`);
+      return null;
+    }
+
+    const imageData = await response.arrayBuffer();
+
+    // Check size (Bluesky limit is 1MB for thumbnails)
+    if (imageData.byteLength > 1000000) {
+      console.error(`Image too large: ${imageData.byteLength} bytes`);
+      return null;
+    }
+
+    // Upload to Bluesky
+    const uploadResponse = await agent.uploadBlob(new Uint8Array(imageData), {
+      encoding: contentType,
+    });
+
+    if (!uploadResponse.success) {
+      console.error('Failed to upload blob');
+      return null;
+    }
+
+    return uploadResponse.data.blob;
+  } catch (error) {
+    console.error(`Error uploading thumbnail:`, error);
+    return null;
+  }
+}

--- a/src/link-preview.ts
+++ b/src/link-preview.ts
@@ -18,7 +18,7 @@ export async function fetchLinkMetadata(url: string): Promise<LinkMetadata | nul
         'User-Agent': 'Bluesky MCP Server/1.0',
         'Accept': 'text/html',
       },
-      signal: AbortSignal.timeout(5000), // 5 second timeout
+      signal: AbortSignal.timeout(15000), // 15 second timeout
     });
 
     if (!response.ok) {
@@ -112,7 +112,7 @@ export async function uploadThumbnail(
       headers: {
         'User-Agent': 'Bluesky MCP Server/1.0',
       },
-      signal: AbortSignal.timeout(10000), // 10 second timeout for images
+      signal: AbortSignal.timeout(20000), // 20 second timeout for images
     });
 
     if (!response.ok) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -275,3 +275,14 @@ export async function convertBskyUrlToAtUri(url: string, agent: AtpAgent): Promi
   }
 }
 
+/**
+ * Extract the first URL from text
+ * Returns null if no URL found
+ */
+export function extractFirstUrl(text: string): string | null {
+  // URL regex that handles common patterns
+  const urlRegex = /https?:\/\/[^\s<>"{}|\\^`\[\]]+/gi;
+  const match = text.match(urlRegex);
+  return match ? match[0] : null;
+}
+


### PR DESCRIPTION
## Summary
Enhances the `create-post` tool with:
1. **Auto-detected facets** - Mentions (@handle), links, and hashtags (#tag) with proper DID resolution
2. **Link preview cards** - Auto-fetch Open Graph metadata and upload thumbnails

## Live Example
See it in action: https://bsky.app/profile/lizthegrey.com/post/3mbfg4vcpyi2f

This post demonstrates:
- Auto-detected URL facet (clickable link)
- Preview card with GitHub PR metadata
- Thumbnail image downloaded and uploaded to Bluesky

## Features

### Facets
- Uses `RichText.detectFacets()` from `@atproto/api` 
- Automatically detects @mentions, URLs, and #hashtags in post text
- Resolves @handles to DIDs via API calls
- Handles UTF-8 byte indexing properly

### Preview Cards (External Embeds)
- Auto-detects first URL in text or accepts explicit `previewUrl` parameter
- Fetches and parses Open Graph / Twitter Card meta tags
- Downloads and uploads thumbnail images via `agent.uploadBlob()`
- Regex-based HTML parsing - no new dependencies
- Graceful degradation on failures (post succeeds even if preview fails)

## New Parameters
- `previewUrl?: string` - Optional explicit URL for preview card
- `embedPreview?: boolean` - Enable/disable preview cards (default: true)

## Implementation

### New Files
- **`src/link-preview.ts`** - Link metadata fetching and thumbnail upload
  - `fetchLinkMetadata(url)` - Fetch URL, parse OG tags via regex
  - `uploadThumbnail(agent, imageUrl)` - Download and upload to Bluesky

### Updated Files
- **`src/utils.ts`** - Added `extractFirstUrl()` helper
- **`src/index.ts`** - Enhanced `create-post` tool with facets and preview cards

## Error Handling (Graceful Degradation)

| Failure Scenario | Behavior |
|------------------|----------|
| @mention doesn't exist | Skip that facet, others still work |
| URL fetch timeout/error | Post created without preview card |
| No OG tags found | Use URL as title |
| Image download fails | Preview card without thumbnail |
| Image >1MB | Preview card without thumbnail |
| Invalid image content-type | Preview card without thumbnail |

## Testing
- Build passes TypeScript checks
- No new dependencies added (uses native `fetch` and regex parsing)
- Tested with various URLs and post formats
- Live example on Bluesky (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 (1M context) <noreply@anthropic.com>