### PR TITLE
Add get-notifications tool with filtering and pagination

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,6 +210,83 @@ server.tool(
 );
 
 server.tool(
+  "get-notifications",
+  "Fetch your notifications from Bluesky, optionally filtered by type (reply, mention, like, repost, follow, quote)",
+  {
+    limit: z.number().min(1).max(500).default(50).describe("Number of notifications to fetch (1-500)"),
+    reasons: z.array(z.enum([
+      "like",
+      "repost",
+      "follow",
+      "mention",
+      "reply",
+      "quote",
+      "starterpack-joined"
+    ])).optional().describe("Filter by notification types (e.g., ['reply', 'mention']). If not provided, returns all types.")
+  },
+  async ({ limit, reasons }) => {
+    if (!agent) {
+      return mcpErrorResponse("Not connected to Bluesky. Check your environment variables.");
+    }
+
+    try {
+      const MAX_NOTIFICATIONS = 500; // Safety limit
+      let allNotifications: any[] = [];
+      let nextCursor: string | undefined = undefined;
+      let shouldContinueFetching = true;
+
+      while (shouldContinueFetching && allNotifications.length < MAX_NOTIFICATIONS) {
+        const batchLimit = Math.min(100, limit - allNotifications.length);
+
+        const response = await agent.app.bsky.notification.listNotifications({
+          limit: batchLimit,
+          cursor: nextCursor,
+          reasons: reasons
+        });
+
+        if (!response.success) {
+          break;
+        }
+
+        const { notifications, cursor } = response.data;
+        allNotifications = allNotifications.concat(notifications);
+        nextCursor = cursor;
+
+        // Stop if we have enough or no more results
+        shouldContinueFetching = allNotifications.length < limit && !!cursor;
+      }
+
+      // Limit to requested count
+      const finalNotifications = allNotifications.slice(0, limit);
+
+      if (finalNotifications.length === 0) {
+        const filterDesc = reasons ? ` with filter: ${reasons.join(', ')}` : '';
+        return mcpSuccessResponse(`No notifications found${filterDesc}.`);
+      }
+
+      // Format notifications output
+      let output = `Retrieved ${finalNotifications.length} notification(s):\n\n`;
+
+      for (const notif of finalNotifications) {
+        const displayName = notif.author.displayName || notif.author.handle;
+        output += `[${notif.reason.toUpperCase()}] ${displayName} (@${notif.author.handle})\n`;
+        output += `  URI: ${notif.uri}\n`;
+        output += `  Time: ${notif.indexedAt}\n`;
+        output += `  Read: ${notif.isRead}\n`;
+        if (notif.reasonSubject) {
+          output += `  Subject: ${notif.reasonSubject}\n`;
+        }
+        output += `\n`;
+      }
+
+      return mcpSuccessResponse(output);
+    } catch (error) {
+      return mcpErrorResponse(`Error fetching notifications: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+);
+
+server.tool(
   "create-post",
   "Create a new post on Bluesky",
   {


### PR DESCRIPTION
## Summary
Adds a new `get-notifications` tool to fetch Bluesky notifications with optional filtering by notification type and full cursor-based pagination.

## Features

### Notification Fetching
- Fetches notifications via `app.bsky.notification.listNotifications` API
- Cursor-based pagination (batches of 100, up to 500 total)
- Returns notification details: author, reason, URI, timestamp, read status, subject

### Filtering by Type
Optional `reasons` parameter to filter notifications by type:
- `reply` - Someone replied to your post
- `mention` - Someone mentioned you in a post
- `like` - Someone liked your post
- `repost` - Someone reposted your post
- `follow` - Someone followed you
- `quote` - Someone quoted your post
- `starterpack-joined` - Someone joined your starter pack

### Parameters
- `limit: number` (1-500, default: 50) - Number of notifications to fetch
- `reasons?: string[]` (optional) - Filter by notification types

### Example Usage
- All notifications: `{ limit: 50 }`
- Only replies: `{ limit: 50, reasons: ['reply'] }`
- Replies and mentions: `{ limit: 50, reasons: ['reply', 'mention'] }`

## Implementation

### Changes
- **File**: `src/index.ts` (added after get-timeline-posts)
- Implements pagination loop similar to timeline tool
- Graceful error handling
- Clear output format with notification type, author, and metadata

### Output Format
```
Retrieved 10 notification(s):

[REPLY] John Doe (@john.bsky.social)
  URI: at://did:plc:abc123/app.bsky.feed.post/xyz789
  Time: 2026-01-01T12:00:00.000Z
  Read: false
  Subject: at://did:plc:abc123/app.bsky.feed.post/original123

[LIKE] Jane Smith (@jane.bsky.social)
  URI: at://did:plc:def456/app.bsky.feed.post/uvw456
  Time: 2026-01-01T11:55:00.000Z
  Read: true
```

## Testing
- Build passes TypeScript checks
- Pagination works correctly with cursor-based fetching
- Filtering by single and multiple notification types works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 (1M context) <noreply@anthropic.com>