### PR TITLE
fix(create-post): auto-detect facets so hashtags / URLs / mentions render as clickable rich text

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { AtpAgent } from "@atproto/api";
+import { AtpAgent, RichText } from "@atproto/api";
 import * as dotenv from "dotenv";
 import {  
   cleanHandle,
@@ -222,8 +222,13 @@ server.tool(
     }
 
     try {
+      // Detect facets so #hashtags, @mentions, and URLs render as
+      // clickable rich text rather than plain text.
+      const rt = new RichText({ text });
+      await rt.detectFacets(agent);
       const record: any = {
-        text,
+        text: rt.text,
+        facets: rt.facets,
         createdAt: new Date().toISOString(),
       };
 


### PR DESCRIPTION
## Problem

`create-post` builds the post record with the raw `text` field only:

```ts
const record: any = { text, createdAt: new Date().toISOString() };
```

When the AppView indexes a post with no `facets` array, hashtags (`#DNS`),
URLs (`https://example.com`) and mentions (`@alice.bsky.social`) are
preserved in the text but never tagged as rich-text features. The
Bluesky web/mobile clients render them as plain text — not blue, not
clickable, not searchable on the hashtag feed.

### Reproducer (against the current `main`)

```
create-post(text: "Writeup: https://example.com\n\n#tag1 #tag2")
```

→ The URL is plain text; clicking it does nothing in the web client.
→ `#tag1` / `#tag2` don't link to the hashtag feed.

## Fix

The `@atproto/api` SDK ships a `RichText` helper exactly for this case.
`rt.detectFacets(agent)` walks the text, finds the byte ranges for each
hashtag / URL / mention, resolves mention handles to DIDs, and attaches
a properly-formed `facets` array to the record.

Two lines: instantiate `RichText`, call `detectFacets`, pass `rt.text` +
`rt.facets` to the record. `agent` is already in scope and is the
expected argument for handle-to-DID resolution.

## Test plan

- [x] Built locally with `npm run build`; no TypeScript errors.
- [x] Posted via the patched build to a test account with one URL and four hashtags → five facets detected, all five render as clickable rich text in the Bluesky web client.
- [x] Plain-text posts (no #, no @, no URL): `rt.facets` is undefined, record omits the field — identical to current behavior.
- [x] Reply posts (when `replyTo` is set): `record.reply` is still attached after the patch.

## Out of scope

- Mention-handle validation (`detectFacets` already resolves handles → DIDs; if a handle doesn't exist, it's left as plain text).
- Custom facet types beyond `tag` / `link` / `mention` (those are SDK-built-in).